### PR TITLE
快捷键检测（基于Windows驱动逆向，不稳定）

### DIFF
--- a/Ksword5.1/Ksword5.1/ArkDriverClient/ArkDriverClient.h
+++ b/Ksword5.1/Ksword5.1/ArkDriverClient/ArkDriverClient.h
@@ -89,6 +89,8 @@ namespace ksword::ark
         IoResult cancelAllPendingCallbackDecisions() const;
         CallbackRemoveResult removeExternalCallback(const KSWORD_ARK_REMOVE_EXTERNAL_CALLBACK_REQUEST& request) const;
         CallbackEnumResult enumerateCallbacks(unsigned long flags = KSWORD_ARK_ENUM_CALLBACK_FLAG_INCLUDE_ALL) const;
+        KeyboardHotkeyEnumResult enumerateKeyboardHotkeys(std::uint32_t processId = 0, unsigned long flags = KSWORD_ARK_KEYBOARD_ENUM_FLAG_INCLUDE_SYSTEM | KSWORD_ARK_KEYBOARD_ENUM_FLAG_INCLUDE_DIAGNOSTICS, unsigned long maxEntries = 2048UL) const;
+        KeyboardHookEnumResult enumerateKeyboardHooks(std::uint32_t processId = 0, unsigned long flags = KSWORD_ARK_KEYBOARD_ENUM_FLAG_INCLUDE_THREAD_HOOKS | KSWORD_ARK_KEYBOARD_ENUM_FLAG_INCLUDE_GLOBAL_HOOKS | KSWORD_ARK_KEYBOARD_ENUM_FLAG_INCLUDE_DIAGNOSTICS, unsigned long maxEntries = 2048UL) const;
         DriverCapabilitiesQueryResult queryDriverCapabilities() const;
         DynDataStatusResult queryDynDataStatus() const;
         DynDataFieldsResult queryDynDataFields() const;

--- a/Ksword5.1/Ksword5.1/ArkDriverClient/ArkDriverTypes.h
+++ b/Ksword5.1/Ksword5.1/ArkDriverClient/ArkDriverTypes.h
@@ -17,6 +17,7 @@
 #include "../../../shared/driver/KswordArkFileMonitorIoctl.h"
 #include "../../../shared/driver/KswordArkHandleIoctl.h"
 #include "../../../shared/driver/KswordArkKernelIoctl.h"
+#include "../../../shared/driver/KswordArkKeyboardIoctl.h"
 #include "../../../shared/driver/KswordArkMemoryIoctl.h"
 #include "../../../shared/driver/KswordArkProcessIoctl.h"
 #include "../../../shared/driver/KswordArkThreadIoctl.h"
@@ -703,6 +704,97 @@ namespace ksword::ark
         std::uint32_t flags = 0;
         long lastStatus = 0;
         std::vector<CallbackEnumEntry> entries;
+    };
+
+    // KeyboardHotkeyEntry 是 R0 win32k RegisterHotKey 内部表的一行 R3 模型。
+    struct KeyboardHotkeyEntry
+    {
+        std::uint32_t source = 0;
+        std::uint32_t status = KSWORD_ARK_KEYBOARD_ENUM_STATUS_UNKNOWN;
+        std::uint32_t flags = 0;
+        std::uint32_t bucketIndex = 0;
+        std::uint32_t depth = 0;
+        std::uint32_t modifiers = 0;
+        std::uint32_t modifierFlags2 = 0;
+        std::uint32_t virtualKey = 0;
+        std::uint32_t hotkeyId = 0;
+        std::uint32_t processId = 0;
+        std::uint32_t threadId = 0;
+        long lastStatus = 0;
+        std::uint64_t hotkeyObject = 0;
+        std::uint64_t nextHotkeyObject = 0;
+        std::uint64_t sessionGlobals = 0;
+        std::uint64_t threadInfo = 0;
+        std::uint64_t threadObject = 0;
+        std::uint64_t windowObject = 0;
+        std::wstring detail;
+    };
+
+    // KeyboardHotkeyEnumResult 承载 R0 键盘热键枚举响应。
+    struct KeyboardHotkeyEnumResult
+    {
+        IoResult io;
+        std::uint32_t version = 0;
+        std::uint32_t status = KSWORD_ARK_KEYBOARD_ENUM_STATUS_UNKNOWN;
+        std::uint32_t totalCount = 0;
+        std::uint32_t returnedCount = 0;
+        std::uint32_t flags = 0;
+        long lastStatus = 0;
+        std::uint64_t win32kBase = 0;
+        std::uint64_t sessionGlobals = 0;
+        std::uint32_t tableOffset = 0;
+        std::uint32_t hotkeyNextOffset = 0;
+        std::uint32_t hotkeyModifiersOffset = 0;
+        std::uint32_t hotkeyVkOffset = 0;
+        std::uint32_t hotkeyIdOffset = 0;
+        std::vector<KeyboardHotkeyEntry> entries;
+    };
+
+    // KeyboardHookEntry 是 R0 win32k WH_KEYBOARD/WH_KEYBOARD_LL 链的一行 R3 模型。
+    struct KeyboardHookEntry
+    {
+        std::uint32_t source = 0;
+        std::uint32_t status = KSWORD_ARK_KEYBOARD_ENUM_STATUS_UNKNOWN;
+        std::uint32_t flags = 0;
+        std::uint32_t hookType = 0;
+        std::uint32_t hookScope = KSWORD_ARK_KEYBOARD_HOOK_SCOPE_UNKNOWN;
+        std::uint32_t processId = 0;
+        std::uint32_t threadId = 0;
+        std::uint32_t moduleId = 0;
+        long lastStatus = 0;
+        std::uint64_t hookObject = 0;
+        std::uint64_t chainHead = 0;
+        std::uint64_t nextHookObject = 0;
+        std::uint64_t threadInfo = 0;
+        std::uint64_t targetThreadInfo = 0;
+        std::uint64_t desktopInfo = 0;
+        std::uint64_t procedureAddress = 0;
+        std::uint64_t procedureOffset = 0;
+        std::uint64_t moduleBase = 0;
+        std::wstring detail;
+    };
+
+    // KeyboardHookEnumResult 承载 R0 键盘钩子枚举响应。
+    struct KeyboardHookEnumResult
+    {
+        IoResult io;
+        std::uint32_t version = 0;
+        std::uint32_t status = KSWORD_ARK_KEYBOARD_ENUM_STATUS_UNKNOWN;
+        std::uint32_t totalCount = 0;
+        std::uint32_t returnedCount = 0;
+        std::uint32_t flags = 0;
+        long lastStatus = 0;
+        std::uint64_t win32kBase = 0;
+        std::uint32_t threadHookArrayOffset = 0;
+        std::uint32_t desktopInfoOffset = 0;
+        std::uint32_t desktopHookArrayOffset = 0;
+        std::uint32_t hookNextOffset = 0;
+        std::uint32_t hookTypeOffset = 0;
+        std::uint32_t hookProcedureOffset = 0;
+        std::uint32_t hookFlagsOffset = 0;
+        std::uint32_t hookModuleIdOffset = 0;
+        std::uint32_t hookTargetThreadInfoOffset = 0;
+        std::vector<KeyboardHookEntry> entries;
     };
 
     // ArkDynModuleIdentity 是 R3 侧模块身份展示结构。

--- a/Ksword5.1/Ksword5.1/Ksword5.1.vcxproj
+++ b/Ksword5.1/Ksword5.1/Ksword5.1.vcxproj
@@ -225,6 +225,7 @@
     <ClCompile Include="ProcessDock\ProcessDetailWindow.cpp" />
     <ClCompile Include="ProcessDock\ProcessDetailWindow.BaseAndUi.cpp" />
     <ClCompile Include="ProcessDock\ProcessDetailWindow.Module.cpp" />
+    <ClCompile Include="ProcessDock\ProcessDetailWindow.Hotkey.cpp" />
     <ClCompile Include="ProcessDock\ProcessDetailWindow.ActionAndUtil.cpp" />
     <ClCompile Include="ProcessDock\ProcessDetailWindow.AdvancedInfo.cpp" />
     <ClCompile Include="ProcessDock\ProcessDock.cpp" />
@@ -293,6 +294,7 @@
     <ClCompile Include="ArkDriverClient\ArkDriverFile.cpp" />
     <ClCompile Include="ArkDriverClient\ArkDriverRegistry.cpp" />
     <ClCompile Include="ArkDriverClient\ArkDriverKernel.cpp" />
+    <ClCompile Include="ArkDriverClient\ArkDriverKeyboard.cpp" />
     <ClCompile Include="ArkDriverClient\ArkDriverCallback.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/Ksword5.1/Ksword5.1/Ksword5.1.vcxproj.filters
+++ b/Ksword5.1/Ksword5.1/Ksword5.1.vcxproj.filters
@@ -301,6 +301,9 @@
     <ClCompile Include="ProcessDock\ProcessDetailWindow.Module.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ProcessDock\ProcessDetailWindow.Hotkey.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="ProcessDock\ProcessDetailWindow.ActionAndUtil.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -509,6 +512,9 @@
       <Filter>Source Files\ArkDriverClient</Filter>
     </ClCompile>
     <ClCompile Include="ArkDriverClient\ArkDriverKernel.cpp">
+      <Filter>Source Files\ArkDriverClient</Filter>
+    </ClCompile>
+    <ClCompile Include="ArkDriverClient\ArkDriverKeyboard.cpp">
       <Filter>Source Files\ArkDriverClient</Filter>
     </ClCompile>
     <ClCompile Include="ArkDriverClient\ArkDriverCallback.cpp">

--- a/Ksword5.1/Ksword5.1/Ksword5.qrc
+++ b/Ksword5.1/Ksword5.1/Ksword5.qrc
@@ -39,6 +39,7 @@
         <file alias="process_open_folder.svg">Resource/Icon/file/folder_open_line.svg</file>
         <file alias="process_priority.svg">Resource/Icon/system/settings_2_line.svg</file>
         <file alias="process_details.svg">Resource/Icon/file/file_info_line.svg</file>
+        <file alias="process_hotkey.svg">Resource/Icon/development/hotkey_line.svg</file>
         <file alias="disk_storage.svg">Resource/Icon/device/storage_line.svg</file>
         <file alias="disk_save.svg">Resource/Icon/file/save_line.svg</file>
         <file alias="disk_warning.svg">Resource/Icon/file/file_warning_line.svg</file>

--- a/Ksword5.1/Ksword5.1/ProcessDock/ProcessDetailWindow.BaseAndUi.cpp
+++ b/Ksword5.1/Ksword5.1/ProcessDock/ProcessDetailWindow.BaseAndUi.cpp
@@ -270,7 +270,11 @@ void ProcessDetailWindow::updateBaseRecord(const ks::process::ProcessRecord& bas
         m_tokenInitialRefreshStarted = false;
         m_tokenSwitchInitialRefreshStarted = false;
         m_sectionInfoInitialRefreshStarted = false;
+        m_hotkeyInitialRefreshStarted = false;
+        m_keyboardInitialRefreshStarted = false;
         m_pebInitialRefreshStarted = false;
+        ++m_hotkeyRefreshTicket;
+        ++m_keyboardRefreshTicket;
     }
     refreshDetailTabTexts();
     if (shouldTryStaticBackgroundRefresh || identityChanged)
@@ -374,6 +378,40 @@ void ProcessDetailWindow::changeEvent(QEvent* event)
         }
     }
 
+    if (m_hotkeyStatusLabel != nullptr)
+    {
+        const QString statusText = m_hotkeyStatusLabel->text();
+        if (m_hotkeyRefreshing)
+        {
+            m_hotkeyStatusLabel->setStyleSheet(buildStateLabelStyle(KswordTheme::PrimaryBlueColor, 700));
+        }
+        else if (statusText.contains(QStringLiteral("无公开API")) || statusText.contains(QStringLiteral("失败")))
+        {
+            m_hotkeyStatusLabel->setStyleSheet(buildStateLabelStyle(statusWarningColor(), 700));
+        }
+        else
+        {
+            m_hotkeyStatusLabel->setStyleSheet(buildStateLabelStyle(statusIdleColor(), 600));
+        }
+    }
+
+    if (m_keyboardStatusLabel != nullptr)
+    {
+        const QString statusText = m_keyboardStatusLabel->text();
+        if (m_keyboardRefreshing)
+        {
+            m_keyboardStatusLabel->setStyleSheet(buildStateLabelStyle(KswordTheme::PrimaryBlueColor, 700));
+        }
+        else if (statusText.contains(QStringLiteral("失败")) || statusText.contains(QStringLiteral("不可用")))
+        {
+            m_keyboardStatusLabel->setStyleSheet(buildStateLabelStyle(statusWarningColor(), 700));
+        }
+        else
+        {
+            m_keyboardStatusLabel->setStyleSheet(buildStateLabelStyle(statusIdleColor(), 600));
+        }
+    }
+
     refreshKernelObjectTabTexts();
 }
 
@@ -412,6 +450,8 @@ void ProcessDetailWindow::applyThemeStyle()
         m_tokenTab,
         m_tokenSwitchTab,
         m_kernelObjectTab,
+        m_hotkeyTab,
+        m_keyboardTab,
         m_pebTab
     };
     for (QWidget* tabPage : tabPageList)
@@ -445,6 +485,18 @@ void ProcessDetailWindow::applyThemeStyle()
     if (m_moduleTable != nullptr && m_moduleTable->header() != nullptr)
     {
         m_moduleTable->header()->setStyleSheet(headerStyle);
+    }
+    if (m_hotkeyTable != nullptr && m_hotkeyTable->horizontalHeader() != nullptr)
+    {
+        m_hotkeyTable->horizontalHeader()->setStyleSheet(headerStyle);
+    }
+    if (m_keyboardHotkeyTable != nullptr && m_keyboardHotkeyTable->horizontalHeader() != nullptr)
+    {
+        m_keyboardHotkeyTable->horizontalHeader()->setStyleSheet(headerStyle);
+    }
+    if (m_keyboardHookTable != nullptr && m_keyboardHookTable->horizontalHeader() != nullptr)
+    {
+        m_keyboardHookTable->horizontalHeader()->setStyleSheet(headerStyle);
     }
 
     if (m_signatureCheckBox != nullptr)
@@ -519,7 +571,7 @@ void ProcessDetailWindow::initializeUi()
     m_tabWidget = new QTabWidget(this);
     m_rootLayout->addWidget(m_tabWidget, 1);
 
-    // 创建七个页面并分别初始化。
+    // 创建各详情页面并分别初始化。
     m_detailTab = new QWidget(m_tabWidget);
     m_threadTab = new QWidget(m_tabWidget);
     m_actionTab = new QWidget(m_tabWidget);
@@ -527,6 +579,8 @@ void ProcessDetailWindow::initializeUi()
     m_tokenTab = new QWidget(m_tabWidget);
     m_tokenSwitchTab = new QWidget(m_tabWidget);
     m_kernelObjectTab = new QWidget(m_tabWidget);
+    m_hotkeyTab = new QWidget(m_tabWidget);
+    m_keyboardTab = new QWidget(m_tabWidget);
     m_pebTab = new QWidget(m_tabWidget);
 
     m_detailTab->setObjectName(QStringLiteral("ProcessDetailTab_Detail"));
@@ -536,6 +590,8 @@ void ProcessDetailWindow::initializeUi()
     m_tokenTab->setObjectName(QStringLiteral("ProcessDetailTab_Token"));
     m_tokenSwitchTab->setObjectName(QStringLiteral("ProcessDetailTab_TokenSwitch"));
     m_kernelObjectTab->setObjectName(QStringLiteral("ProcessDetailTab_KernelObject"));
+    m_hotkeyTab->setObjectName(QStringLiteral("ProcessDetailTab_Hotkey"));
+    m_keyboardTab->setObjectName(QStringLiteral("ProcessDetailTab_Keyboard"));
     m_pebTab->setObjectName(QStringLiteral("ProcessDetailTab_Peb"));
 
     initializeDetailTab();
@@ -545,6 +601,8 @@ void ProcessDetailWindow::initializeUi()
     initializeTokenTab();
     initializeTokenSwitchTab();
     initializeKernelObjectTab();
+    initializeHotkeyTab();
+    initializeKeyboardTab();
     initializePebTab();
 
     // 为 Tab 指定图标与标题文本。
@@ -555,6 +613,8 @@ void ProcessDetailWindow::initializeUi()
     m_tabWidget->addTab(m_tokenTab, QIcon(":/Icon/process_critical.svg"), "令牌");
     m_tabWidget->addTab(m_tokenSwitchTab, QIcon(":/Icon/process_start.svg"), "令牌开关");
     m_tabWidget->addTab(m_kernelObjectTab, QIcon(":/Icon/process_critical.svg"), "内核对象");
+    m_tabWidget->addTab(m_hotkeyTab, QIcon(":/Icon/process_hotkey.svg"), "进程热键");
+    m_tabWidget->addTab(m_keyboardTab, QIcon(":/Icon/process_hotkey.svg"), "键盘");
     m_tabWidget->addTab(m_pebTab, QIcon(":/Icon/process_tree.svg"), "PEB");
     m_tabWidget->setCurrentWidget(m_detailTab);
 
@@ -622,6 +682,24 @@ void ProcessDetailWindow::requestInitialRefreshForCurrentTab()
         if (!m_sectionInfoInitialRefreshStarted)
         {
             requestAsyncSectionRefresh();
+        }
+        return;
+    }
+
+    if (currentTab == m_hotkeyTab)
+    {
+        if (!m_hotkeyInitialRefreshStarted)
+        {
+            requestAsyncHotkeyRefresh();
+        }
+        return;
+    }
+
+    if (currentTab == m_keyboardTab)
+    {
+        if (!m_keyboardInitialRefreshStarted)
+        {
+            requestAsyncKeyboardRefresh();
         }
         return;
     }
@@ -1799,6 +1877,16 @@ void ProcessDetailWindow::initializeConnections()
     // Section/ControlArea 刷新按钮：只传 PID 给 ArkDriverClient，避免 UI 回传内核地址。
     connect(m_refreshSectionInfoButton, &QPushButton::clicked, this, [this]() {
         requestAsyncSectionRefresh();
+    });
+
+    // 进程热键页刷新按钮。
+    connect(m_refreshHotkeyButton, &QPushButton::clicked, this, [this]() {
+        requestAsyncHotkeyRefresh();
+    });
+
+    // 键盘页刷新按钮：热键与键盘钩子一起刷新。
+    connect(m_refreshKeyboardButton, &QPushButton::clicked, this, [this]() {
+        requestAsyncKeyboardRefresh();
     });
 
     // Tab 首次切换时再启动对应重型刷新：

--- a/Ksword5.1/Ksword5.1/ProcessDock/ProcessDetailWindow.InternalCommon.h
+++ b/Ksword5.1/Ksword5.1/ProcessDock/ProcessDetailWindow.InternalCommon.h
@@ -22,6 +22,8 @@
 #include <QClipboard>
 #include <QColor>
 #include <QComboBox>
+#include <QDir>
+#include <QDirIterator>
 #include <QEvent>
 #include <QFile>
 #include <QFileDialog>
@@ -41,7 +43,9 @@
 #include <QPointer>
 #include <QPushButton>
 #include <QRunnable>
+#include <QSet>
 #include <QStringList>
+#include <QStandardPaths>
 #include <QTableWidget>
 #include <QTableWidgetItem>
 #include <QTabWidget>
@@ -68,12 +72,17 @@
 #endif
 #include <Windows.h>
 #include <Psapi.h>
+#include <ShObjIdl.h>
+#include <ShlObj.h>
 #include <TlHelp32.h>
 #include <winternl.h>
 #include <sddl.h>
 
 #pragma comment(lib, "Psapi.lib")
 #pragma comment(lib, "Advapi32.lib")
+#pragma comment(lib, "Ole32.lib")
+#pragma comment(lib, "Shell32.lib")
+#pragma comment(lib, "Uuid.lib")
 
 namespace process_detail_window_internal
 {

--- a/Ksword5.1/Ksword5.1/ProcessDock/ProcessDetailWindow.h
+++ b/Ksword5.1/Ksword5.1/ProcessDock/ProcessDetailWindow.h
@@ -127,6 +127,53 @@ private:
         std::uint64_t elapsedMs = 0;     // 刷新耗时（毫秒）。
     };
 
+    // HotkeyInspectItem：进程热键页单行数据。
+    struct HotkeyInspectItem
+    {
+        QString objectText;              // HWND/HMENU/资源/快捷方式路径。
+        std::uint32_t hotkeyId = 0;      // 菜单命令 ID / Accelerator 命令 ID / 0。
+        std::uint32_t modifiers = 0;     // MOD_ALT/MOD_CONTROL/MOD_SHIFT/MOD_WIN 位图。
+        std::uint32_t virtualKey = 0;    // 虚拟键码，未知时为 0。
+        QString hotkeyText;              // 可读快捷键文本。
+        std::uint32_t processId = 0;     // 所属进程 ID。
+        std::uint32_t threadId = 0;      // 所属窗口线程 ID，非窗口来源为 0。
+        QString processName;             // 所属进程名。
+        QString sourceText;              // 来源：窗口热键/菜单/Accelerator/.lnk 等。
+        QString detailText;              // 额外上下文。
+    };
+
+    // HotkeyInspectRefreshResult：进程热键异步刷新结果。
+    struct HotkeyInspectRefreshResult
+    {
+        std::vector<HotkeyInspectItem> rows; // 热键行数据。
+        QString diagnosticText;              // 诊断文本。
+        std::uint64_t elapsedMs = 0;         // 刷新耗时（毫秒）。
+    };
+
+    // KeyboardHookInspectItem：键盘页钩子表单行数据。
+    struct KeyboardHookInspectItem
+    {
+        QString objectText;       // tagHOOK 对象地址。
+        QString typeText;         // WH_KEYBOARD / WH_KEYBOARD_LL。
+        QString scopeText;        // 线程链 / 全局链。
+        std::uint32_t processId = 0;
+        std::uint32_t threadId = 0;
+        QString procedureText;    // 回调地址或 R0 保存的回调偏移。
+        QString moduleText;       // 模块基址或 module id。
+        QString sourceText;       // 来源链。
+        QString flagsText;        // tagHOOK flags。
+        QString detailText;       // 链头、next、threadInfo 等诊断字段。
+    };
+
+    // KeyboardInspectRefreshResult：键盘页异步刷新结果。
+    struct KeyboardInspectRefreshResult
+    {
+        std::vector<HotkeyInspectItem> hotkeyRows;     // 热键行数据。
+        std::vector<KeyboardHookInspectItem> hookRows; // 钩子行数据。
+        QString diagnosticText;                        // 诊断文本。
+        std::uint64_t elapsedMs = 0;                   // 刷新耗时（毫秒）。
+    };
+
     // StaticDetailRefreshResult：进程静态详情后台补齐结果。
     struct StaticDetailRefreshResult
     {
@@ -167,6 +214,20 @@ private:
     // 参数：无。
     // 返回：无。
     void initializeKernelObjectTab();
+    // initializeHotkeyTab 作用：
+    // - 构建“进程热键”页面；
+    // - 覆盖窗口激活热键、菜单快捷键、PE Accelerator 资源和 .lnk 快捷方式热键。
+    // 调用方式：initializeUi 中创建 m_hotkeyTab 后调用。
+    // 参数：无。
+    // 返回：无。
+    void initializeHotkeyTab();
+    // initializeKeyboardTab 作用：
+    // - 构建“键盘”页面；
+    // - 同时展示热键检测结果和 R0 键盘钩子链枚举结果。
+    // 调用方式：initializeUi 中创建 m_keyboardTab 后调用。
+    // 参数：无。
+    // 返回：无。
+    void initializeKeyboardTab();
     // initializeTokenSwitchTab 作用：
     // - 构建“令牌开关”页面；
     // - 提供复选框批量控制 Token 开关位，并提供刷新/应用按钮。
@@ -225,6 +286,27 @@ private:
     void requestAsyncPebRefresh();
     void applyTokenRefreshResult(const TextRefreshResult& refreshResult);
     void applyPebRefreshResult(const TextRefreshResult& refreshResult);
+    // requestAsyncHotkeyRefresh 作用：
+    // - 后台扫描当前进程相关热键来源；
+    // - 不直接访问驱动，不阻塞详情窗口 UI 线程。
+    // 调用方式：热键页首刷或点击刷新按钮。
+    // 参数：无。
+    // 返回：无。
+    void requestAsyncHotkeyRefresh();
+    // applyHotkeyRefreshResult 作用：
+    // - 在主线程回填热键检测结果；
+    // - 重建表格并更新状态标签。
+    // 调用方式：requestAsyncHotkeyRefresh 后台任务完成后投递。
+    // 参数 refreshResult：后台扫描结果。
+    // 返回：无。
+    void applyHotkeyRefreshResult(const HotkeyInspectRefreshResult& refreshResult);
+    void rebuildHotkeyTable();
+    void updateHotkeyStatusLabel(const QString& statusText, bool refreshing);
+    void requestAsyncKeyboardRefresh();
+    void applyKeyboardRefreshResult(const KeyboardInspectRefreshResult& refreshResult);
+    void rebuildKeyboardHotkeyTable();
+    void rebuildKeyboardHookTable();
+    void updateKeyboardStatusLabel(const QString& statusText, bool refreshing);
     // requestAsyncSectionRefresh 作用：
     // - 通过 ArkDriverClient 异步查询 R0 SectionObject / ControlArea；
     // - 只传 PID，不把 UI 看到的内核地址传回驱动。
@@ -323,6 +405,8 @@ private:
     QWidget* m_tokenTab = nullptr;             // “令牌”页。
     QWidget* m_tokenSwitchTab = nullptr;       // “令牌开关”页。
     QWidget* m_kernelObjectTab = nullptr;      // “内核对象”页。
+    QWidget* m_hotkeyTab = nullptr;            // “进程热键”页。
+    QWidget* m_keyboardTab = nullptr;          // “键盘”页。
     QWidget* m_pebTab = nullptr;               // “PEB”页。
 
     // ======== 详细信息页控件 ========
@@ -430,6 +514,31 @@ private:
     bool m_sectionInfoInitialRefreshStarted = false; // Section 页首次查询是否已经按需启动。
     std::uint64_t m_sectionInfoRefreshTicket = 0; // Section 查询序号。
     int m_sectionInfoRefreshProgressPid = 0; // Section 查询 kPro 任务 PID。
+
+    // ======== 进程热键页控件与状态 ========
+    QVBoxLayout* m_hotkeyLayout = nullptr;       // 进程热键页总布局。
+    QPushButton* m_refreshHotkeyButton = nullptr; // 刷新热键按钮。
+    QLabel* m_hotkeyStatusLabel = nullptr;       // 热键扫描状态。
+    QTableWidget* m_hotkeyTable = nullptr;       // 热键结果表。
+    bool m_hotkeyRefreshing = false;             // 热键扫描是否进行中。
+    bool m_hotkeyInitialRefreshStarted = false;  // 热键页首次扫描是否已经按需启动。
+    std::uint64_t m_hotkeyRefreshTicket = 0;     // 热键扫描序号。
+    int m_hotkeyRefreshProgressPid = 0;          // 热键扫描 kPro 任务 PID。
+    std::vector<HotkeyInspectItem> m_hotkeyRows; // 热键结果缓存。
+
+    // ======== 键盘页控件与状态 ========
+    QVBoxLayout* m_keyboardLayout = nullptr;       // 键盘页总布局。
+    QPushButton* m_refreshKeyboardButton = nullptr; // 刷新键盘按钮。
+    QLabel* m_keyboardStatusLabel = nullptr;       // 键盘页扫描状态。
+    QTabWidget* m_keyboardInnerTabWidget = nullptr; // 键盘页内部热键/钩子分栏。
+    QTableWidget* m_keyboardHotkeyTable = nullptr; // 键盘页热键表。
+    QTableWidget* m_keyboardHookTable = nullptr;   // 键盘钩子结果表。
+    bool m_keyboardRefreshing = false;             // 键盘页扫描是否进行中。
+    bool m_keyboardInitialRefreshStarted = false;  // 键盘页首次扫描是否已启动。
+    std::uint64_t m_keyboardRefreshTicket = 0;     // 键盘页扫描序号。
+    int m_keyboardRefreshProgressPid = 0;          // 键盘页扫描 kPro 任务 PID。
+    std::vector<HotkeyInspectItem> m_keyboardHotkeyRows; // 键盘页热键缓存。
+    std::vector<KeyboardHookInspectItem> m_keyboardHookRows; // 键盘页钩子缓存。
 
     // ======== 令牌页控件与状态 ========
     QVBoxLayout* m_tokenLayout = nullptr;          // 令牌页布局。

--- a/KswordARKDriver/KswordARKDriver.vcxproj
+++ b/KswordARKDriver/KswordARKDriver.vcxproj
@@ -99,6 +99,8 @@
     <ClCompile Include="src\features\network\network_runtime.c" />
     <ClCompile Include="src\features\network\network_wfp.c" />
     <ClCompile Include="src\features\network\network_ioctl.c" />
+    <ClCompile Include="src\features\keyboard\keyboard_query.c" />
+    <ClCompile Include="src\features\keyboard\keyboard_ioctl.c" />
   <ClCompile Include="src\features\callback\callback_external_wfp.c" /><ClCompile Include="src\features\callback\callback_external_minifilter.c" /><ClCompile Include="src\features\callback\callback_external_safe.c" /><ClCompile Include="src\features\memory\memory_physical.c" /><ClCompile Include="src\features\memory\memory_pagetable.c" /><ClCompile Include="src\features\memory\memory_ioctl.c" /></ItemGroup>
   <ItemGroup>
     <ClInclude Include="Device.h" />
@@ -143,6 +145,7 @@
     <ClInclude Include="src\dispatch\ioctl_validation.h" />
     <ClInclude Include="include\ark\ark_redirect.h" />
     <ClInclude Include="include\ark\ark_network.h" />
+    <ClInclude Include="include\ark\ark_keyboard.h" />
     <ClInclude Include="src\features\redirect\redirect_internal.h" />
     <ClInclude Include="src\features\network\network_internal.h" />
     <ClInclude Include="src\features\kernel\hook_scan_support.h" />

--- a/KswordARKDriver/KswordARKDriver.vcxproj.filters
+++ b/KswordARKDriver/KswordARKDriver.vcxproj.filters
@@ -80,6 +80,9 @@
     <Filter Include="Source Files\Features\Network">
       <UniqueIdentifier>{541AEFAF-60EB-42D1-91CC-8DC0CF5988B4}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\Features\Keyboard">
+      <UniqueIdentifier>{7B0CB69A-3F6D-4519-B7D7-D38809229979}</UniqueIdentifier>
+    </Filter>
   <Filter Include="Source Files\Features\Memory"><UniqueIdentifier>{8F66C0B8-48D7-45BE-8D5E-6626DD52CFC4}</UniqueIdentifier></Filter></ItemGroup>
   <ItemGroup>
     <None Include="ReadMe.txt" />
@@ -217,6 +220,9 @@
       <Filter>Header Files\Ark</Filter>
     </ClInclude>
     <ClInclude Include="include\ark\ark_network.h">
+      <Filter>Header Files\Ark</Filter>
+    </ClInclude>
+    <ClInclude Include="include\ark\ark_keyboard.h">
       <Filter>Header Files\Ark</Filter>
     </ClInclude>
     <ClInclude Include="src\features\network\network_internal.h">
@@ -457,6 +463,12 @@
     </ClCompile>
     <ClCompile Include="src\features\network\network_wfp.c">
       <Filter>Source Files\Features\Network</Filter>
+    </ClCompile>
+    <ClCompile Include="src\features\keyboard\keyboard_query.c">
+      <Filter>Source Files\Features\Keyboard</Filter>
+    </ClCompile>
+    <ClCompile Include="src\features\keyboard\keyboard_ioctl.c">
+      <Filter>Source Files\Features\Keyboard</Filter>
     </ClCompile>
   <ClCompile Include="src\features\callback\callback_external_wfp.c"><Filter>Source Files\Features\Callback</Filter></ClCompile><ClCompile Include="src\features\callback\callback_external_minifilter.c"><Filter>Source Files\Features\Callback</Filter></ClCompile><ClCompile Include="src\features\callback\callback_external_safe.c"><Filter>Source Files\Features\Callback</Filter></ClCompile><ClCompile Include="src\features\memory\memory_physical.c"><Filter>Source Files\Features\Memory</Filter></ClCompile><ClCompile Include="src\features\memory\memory_pagetable.c"><Filter>Source Files\Features\Memory</Filter></ClCompile><ClCompile Include="src\features\memory\memory_ioctl.c"><Filter>Source Files\Features\Memory</Filter></ClCompile></ItemGroup>
 </Project>

--- a/KswordARKDriver/include/ark/ark_driver.h
+++ b/KswordARKDriver/include/ark/ark_driver.h
@@ -29,6 +29,7 @@
 #include "ark_registry.h"
 #include "ark_redirect.h"
 #include "ark_network.h"
+#include "ark_keyboard.h"
 #include "Trace.h"
 
 EXTERN_C_START

--- a/KswordARKDriver/include/ark/ark_ioctl.h
+++ b/KswordARKDriver/include/ark/ark_ioctl.h
@@ -19,3 +19,4 @@
 #include "driver/KswordArkRegistryIoctl.h"
 #include "driver/KswordArkRedirectIoctl.h"
 #include "driver/KswordArkNetworkIoctl.h"
+#include "driver/KswordArkKeyboardIoctl.h"

--- a/KswordARKDriver/src/dispatch/ioctl_registry.c
+++ b/KswordARKDriver/src/dispatch/ioctl_registry.c
@@ -78,6 +78,8 @@ NTSTATUS KswordARKRedirectIoctlSetRules(_In_ WDFDEVICE Device, _In_ WDFREQUEST R
 NTSTATUS KswordARKRedirectIoctlQueryStatus(_In_ WDFDEVICE Device, _In_ WDFREQUEST Request, _In_ size_t InputBufferLength, _In_ size_t OutputBufferLength, _Out_ size_t* BytesReturned);
 NTSTATUS KswordARKNetworkIoctlSetRules(_In_ WDFDEVICE Device, _In_ WDFREQUEST Request, _In_ size_t InputBufferLength, _In_ size_t OutputBufferLength, _Out_ size_t* BytesReturned);
 NTSTATUS KswordARKNetworkIoctlQueryStatus(_In_ WDFDEVICE Device, _In_ WDFREQUEST Request, _In_ size_t InputBufferLength, _In_ size_t OutputBufferLength, _Out_ size_t* BytesReturned);
+NTSTATUS KswordARKKeyboardIoctlEnumHotkeys(_In_ WDFDEVICE Device, _In_ WDFREQUEST Request, _In_ size_t InputBufferLength, _In_ size_t OutputBufferLength, _Out_ size_t* BytesReturned);
+NTSTATUS KswordARKKeyboardIoctlEnumHooks(_In_ WDFDEVICE Device, _In_ WDFREQUEST Request, _In_ size_t InputBufferLength, _In_ size_t OutputBufferLength, _Out_ size_t* BytesReturned);
 
 static const KSWORD_ARK_IOCTL_ENTRY g_KswordArkIoctlTable[] = {
     { IOCTL_KSWORD_ARK_TERMINATE_PROCESS, KswordARKProcessIoctlTerminate, "IOCTL_KSWORD_ARK_TERMINATE_PROCESS", KSWORD_ARK_IOCTL_CAPABILITY_NONE, KSWORD_ARK_IOCTL_FLAG_NONE },
@@ -139,7 +141,9 @@ static const KSWORD_ARK_IOCTL_ENTRY g_KswordArkIoctlTable[] = {
     { IOCTL_KSWORD_ARK_REDIRECT_SET_RULES, KswordARKRedirectIoctlSetRules, "IOCTL_KSWORD_ARK_REDIRECT_SET_RULES", KSWORD_ARK_IOCTL_CAPABILITY_NONE, KSWORD_ARK_IOCTL_FLAG_NONE },
     { IOCTL_KSWORD_ARK_REDIRECT_QUERY_STATUS, KswordARKRedirectIoctlQueryStatus, "IOCTL_KSWORD_ARK_REDIRECT_QUERY_STATUS", KSWORD_ARK_IOCTL_CAPABILITY_NONE, KSWORD_ARK_IOCTL_FLAG_NONE },
     { IOCTL_KSWORD_ARK_NETWORK_SET_RULES, KswordARKNetworkIoctlSetRules, "IOCTL_KSWORD_ARK_NETWORK_SET_RULES", KSWORD_ARK_IOCTL_CAPABILITY_NONE, KSWORD_ARK_IOCTL_FLAG_NONE },
-    { IOCTL_KSWORD_ARK_NETWORK_QUERY_STATUS, KswordARKNetworkIoctlQueryStatus, "IOCTL_KSWORD_ARK_NETWORK_QUERY_STATUS", KSWORD_ARK_IOCTL_CAPABILITY_NONE, KSWORD_ARK_IOCTL_FLAG_NONE }
+    { IOCTL_KSWORD_ARK_NETWORK_QUERY_STATUS, KswordARKNetworkIoctlQueryStatus, "IOCTL_KSWORD_ARK_NETWORK_QUERY_STATUS", KSWORD_ARK_IOCTL_CAPABILITY_NONE, KSWORD_ARK_IOCTL_FLAG_NONE },
+    { IOCTL_KSWORD_ARK_ENUM_KEYBOARD_HOTKEYS, KswordARKKeyboardIoctlEnumHotkeys, "IOCTL_KSWORD_ARK_ENUM_KEYBOARD_HOTKEYS", KSWORD_ARK_IOCTL_CAPABILITY_NONE, KSWORD_ARK_IOCTL_FLAG_NONE },
+    { IOCTL_KSWORD_ARK_ENUM_KEYBOARD_HOOKS, KswordARKKeyboardIoctlEnumHooks, "IOCTL_KSWORD_ARK_ENUM_KEYBOARD_HOOKS", KSWORD_ARK_IOCTL_CAPABILITY_NONE, KSWORD_ARK_IOCTL_FLAG_NONE }
 };
 
 _Must_inspect_result_


### PR DESCRIPTION
仅兼容Windows11 25H2的键盘快捷键检测器，基于Windows驱动逆向开发